### PR TITLE
Add git to images so pip installs of git repos work

### DIFF
--- a/senv/Dockerfile
+++ b/senv/Dockerfile
@@ -1,6 +1,13 @@
 ARG PY_VERSION
 FROM python:$PY_VERSION-slim
 
+# Git is kinda heavy, but often necessary to install packages.
+# See https://github.com/docker-library/python/issues/391#issuecomment-481762593
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get purge -y --auto-remove && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN python3 -c "from urllib.request import urlopen; exec(urlopen('https://install.python-poetry.org').read())"
 
 RUN mv /usr/local/bin/python /usr/local/bin/python.real

--- a/sneks/tests/Dockerfile
+++ b/sneks/tests/Dockerfile
@@ -3,6 +3,14 @@
 ARG PY_VERSION=3.9.1
 FROM python:$PY_VERSION-slim
 
+# Git is kinda heavy, but often necessary to install packages.
+# See https://github.com/docker-library/python/issues/391#issuecomment-481762593
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+
+
 RUN python3 -c "from urllib.request import urlopen; exec(urlopen('https://install.python-poetry.org').read())"
 
 RUN pip install distributed bokeh


### PR DESCRIPTION
This sucks. The images are getting to be about 500mb now. That's way, way too big. Especially since everything we need (python, git) is already in the AMI.

However, being able to install from a git URL is pretty important.